### PR TITLE
Fix an undefinition macro `TRC_CHANNEL` in a component template

### DIFF
--- a/ComponentTemplate/ComponentTemplate.cpp
+++ b/ComponentTemplate/ComponentTemplate.cpp
@@ -19,7 +19,7 @@
 #include "ComponentTemplate.h"
 
 #ifdef TRC_CHANNEL
-#undefine TRC_CHANNEL
+#undef TRC_CHANNEL
 #endif
 #define TRC_CHANNEL 1
 


### PR DESCRIPTION
Signed-off-by: Roman Ondráček <ondracek.roman@centrum.cz>